### PR TITLE
feat(hook): add `useToggle` hook

### DIFF
--- a/src/use-toggle.ts
+++ b/src/use-toggle.ts
@@ -13,7 +13,7 @@ export const useToggle = (initial: boolean = false): [boolean, (value: boolean) 
     const [toggled, setToggled] = useState(initial)
 
     const handleToggle = (value: boolean) => {
-        setToggled(value)
+        setToggled((previous) => (value ? value : !previous))
     }
 
     return [toggled, handleToggle]

--- a/src/use-toggle.ts
+++ b/src/use-toggle.ts
@@ -1,0 +1,20 @@
+"use client"
+import { useState } from "react"
+
+/**
+ * useToggle is a React hook that manages a boolean toggle state.
+ *
+ * @param {boolean} initial - Initial state of the toggle, defaults to false.
+ * @returns {Function} - Returns the current toggle state and a function to update it.
+ * @example
+ * const [isToggled, toggle] = useToggle();
+ */
+export const useToggle = (initial: boolean = false): [boolean, (value: boolean) => void] => {
+    const [toggled, setToggled] = useState(initial)
+
+    const handleToggle = (value: boolean) => {
+        setToggled(value)
+    }
+
+    return [toggled, handleToggle]
+}


### PR DESCRIPTION
## Description

This pull request adds the `useToggle` hook, which provides a simple way to manage a boolean toggle state.  
The hook returns a state value along with a function to toggle it, making it ideal for handling UI states such as menus, dialogs, or toggles.

### ✅ Example Usage

```ts
import { useToggle } from "@halvaradop/hooks"

const [isOpenMenu, toggleMenu] = useToggle(false)
const [isOpenDialog, toggleDialog] = useToggle(false)
```

<!--Provide a detailed description or reasoning for the changes made -->

## Checklist

- [x] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [x] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
