### PR TITLE
feat(hooks): add `useInterval` hook

### DIFF
--- a/src/use-interval.ts
+++ b/src/use-interval.ts
@@ -1,0 +1,22 @@
+"use client"
+import { useEffect, useRef } from "react"
+
+export const useInterval = (callback: VoidFunction, delay: number | null) => {
+    const callbackRef = useRef<VoidFunction>(callback)
+
+    useEffect(() => {
+        callbackRef.current = callback
+    }, [callback])
+
+    useEffect(() => {
+        if (!delay) return
+
+        const idle = setInterval(() => {
+            callbackRef.current()
+        }, delay)
+
+        return () => {
+            clearInterval(idle)
+        }
+    }, [delay])
+}

--- a/src/use-interval.ts
+++ b/src/use-interval.ts
@@ -1,6 +1,21 @@
 "use client"
 import { useEffect, useRef } from "react"
 
+/**
+ * `useInterval` is a custom hook that sets up an interval to call a callback function at specified intervals.
+ *
+ * @param {VoidFunction} callback - The function to be called at each interval.
+ * @param {number | null} delay - The interval delay in milliseconds. If null, the interval is not set.
+ * @example
+ * useInterval(() => {
+ *   console.log("This will run every 1000ms");
+ * }, 1000);
+ *
+ * const [isActive, setIsActive] = useState(true);
+ * useInterval(() => {
+ *   console.log("This will run every 1000ms only if isActive is true");
+ * }, isActive ? 1000 : null);
+ */
 export const useInterval = (callback: VoidFunction, delay: number | null) => {
     const callbackRef = useRef<VoidFunction>(callback)
 


### PR DESCRIPTION
## Description

This pull request adds the `useInterval` hook, a utility that allows scheduling a function to run repeatedly at a specified time interval in React components.

The hook provides a declarative way to use `setInterval`, handling automatic clearing and rescheduling when the delay or callback changes.

### Key Features

- Repeatedly invokes a callback function after the specified delay
- Handles updates to the callback or delay dynamically
- Automatically clears the interval on component unmount
- Prevents stale closures by referencing the latest callback

This hook is useful for polling data, running timers, or triggering animations at regular intervals.

## Checklist

- [x] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code.
- [x] All tests have been added and pass successfully.

## Notes

