### PR TITLE
refactor(hooks): add deps and enable options support in useEventListener

### DIFF
--- a/src/use-broadcast-channel.ts
+++ b/src/use-broadcast-channel.ts
@@ -42,14 +42,14 @@ export const useBroadcastChannel = <T>(name: string, initialValue?: T): Broadcas
         if (!isSupported) return
         broadcastChannel.current ??= new BroadcastChannel(name)
 
-        const syncBroadcast = (event: MessageEvent) => {
+        const handleBroadcastMessage = (event: MessageEvent) => {
             setState(event.data)
         }
 
-        broadcastChannel.current.addEventListener("message", syncBroadcast)
+        broadcastChannel.current.addEventListener("message", handleBroadcastMessage)
 
         return () => {
-            broadcastChannel.current?.removeEventListener("message", syncBroadcast)
+            broadcastChannel.current?.removeEventListener("message", handleBroadcastMessage)
             broadcastChannel.current?.close()
             setState(undefined)
         }

--- a/src/use-event-listener.ts
+++ b/src/use-event-listener.ts
@@ -78,15 +78,15 @@ const getTarget = (target: TargetRef<EventTargetWithRef>): EventTarget => {
 export const useEventListener = <T extends EventTargetWithRef, K extends keyof EventMap<T>>(
     target: TargetRef<T>,
     type: K,
-    event: (this: T, ev: EventMap<T>[K]) => any,
+    handler: (this: T, ev: EventMap<T>[K]) => any,
     options: EventListenerOptions = {},
 ) => {
-    const callbackRef = useRef<Function>(event)
+    const callbackRef = useRef<Function>(handler)
     const { options: eventOptions, deps = [], enabled = false } = options
 
     useEffect(() => {
-        callbackRef.current = event
-    }, [event])
+        callbackRef.current = handler
+    }, [handler])
 
     useEffect(() => {
         const isEnabled = enabled instanceof Function ? enabled() : enabled

--- a/src/use-event-listener.ts
+++ b/src/use-event-listener.ts
@@ -94,9 +94,9 @@ export const useEventListener = <T extends EventTargetWithRef, K extends keyof E
         const get = getTarget(target)
         if (!get) return
 
-        const eventListener = (ev: Event) => callbackRef.current(ev)
-        get.addEventListener(type as string, eventListener, eventOptions)
+        const handleListener = (ev: Event) => callbackRef.current(ev)
+        get.addEventListener(type as string, handleListener, eventOptions)
 
-        return () => get.removeEventListener(type as string, eventListener, eventOptions)
+        return () => get.removeEventListener(type as string, handleListener, eventOptions)
     }, [type, target, eventOptions, enabled, ...deps])
 }

--- a/src/use-local-storage.ts
+++ b/src/use-local-storage.ts
@@ -1,5 +1,6 @@
 "use client"
 import { useState, useCallback, useEffect } from "react"
+import { useWindowEventListener } from "@/use-window-event-listener"
 
 /**
  * Default serializer for `useLocalStorage` hook
@@ -63,14 +64,11 @@ export const useLocalStorage = <T>(key: string, initialValue?: T, options: UseLo
 
     const { withEvent = false, serializer = defaultSerializer } = options
     const { serialize, deserialize } = serializer
-
-    const isBrowser = useCallback((): boolean => {
-        return typeof window !== "undefined" && typeof window.localStorage !== "undefined"
-    }, [])
+    const isSupported = typeof window !== "undefined" && typeof localStorage !== "undefined"
 
     const setValue: UseLocalStorageReturn<T>["setValue"] = useCallback(
         (value) => {
-            if (!isBrowser()) return
+            if (!isSupported) return
             setStorage((previous) => {
                 const valueToStore = value instanceof Function ? value(previous) : value
                 const storageValue = serialize(valueToStore)
@@ -82,7 +80,7 @@ export const useLocalStorage = <T>(key: string, initialValue?: T, options: UseLo
     )
 
     const getStorage = useCallback(() => {
-        if (!isBrowser()) return
+        if (!isSupported) return
         const getItem = localStorage.getItem(key)
         const storageValue = getItem ? deserialize(getItem) : initialValue
         localStorage.setItem(key, serialize(storageValue))
@@ -93,26 +91,23 @@ export const useLocalStorage = <T>(key: string, initialValue?: T, options: UseLo
     const removeItem: UseLocalStorageReturn<T>["removeItem"] = useCallback(() => {
         setStorage(() => undefined)
         localStorage.removeItem(key)
-    }, [key, isBrowser])
+    }, [key, isSupported])
 
     useEffect(() => {
         getStorage()
     }, [key, serializer])
 
-    useEffect(() => {
-        if (!withEvent || !isBrowser()) return
-
-        const syncStorage = (event: StorageEvent) => {
+    useWindowEventListener(
+        "storage",
+        (event: StorageEvent) => {
             const { key, newValue } = event
             if (event.key === key) {
                 const newContextValue = newValue ? deserialize(newValue) : undefined
                 setStorage(newContextValue)
             }
-        }
+        },
+        { deps: [serializer, key, withEvent, isSupported], enabled: withEvent && isSupported },
+    )
 
-        window.addEventListener("storage", syncStorage)
-        return () => window.removeEventListener("storage", syncStorage)
-    }, [key, serializer, withEvent, isBrowser])
-
-    return [storage, setValue, removeItem]
+    return [storage, setValue, removeItem] as const
 }

--- a/src/use-local-storage.ts
+++ b/src/use-local-storage.ts
@@ -93,12 +93,7 @@ export const useLocalStorage = <T>(key: string, initialValue?: T, options: UseLo
         localStorage.removeItem(key)
     }, [key, isSupported])
 
-    useEffect(() => {
-        getStorage()
-    }, [key, serializer])
-
-    useWindowEventListener(
-        "storage",
+    const handleStorage = useCallback(
         (event: StorageEvent) => {
             const { key, newValue } = event
             if (event.key === key) {
@@ -106,8 +101,17 @@ export const useLocalStorage = <T>(key: string, initialValue?: T, options: UseLo
                 setStorage(newContextValue)
             }
         },
-        { deps: [serializer, key, withEvent, isSupported], enabled: withEvent && isSupported },
+        [key, deserialize],
     )
+
+    useEffect(() => {
+        getStorage()
+    }, [key, serializer])
+
+    useWindowEventListener("storage", handleStorage, {
+        deps: [serializer, key, withEvent, isSupported],
+        enabled: withEvent && isSupported,
+    })
 
     return [storage, setValue, removeItem] as const
 }

--- a/src/use-media-query.ts
+++ b/src/use-media-query.ts
@@ -26,8 +26,10 @@ export type MediaQuery = Query | `(${Query})`
  */
 export const useMediaQuery = (mediaQuery: MediaQuery): boolean => {
     const [isMatched, setIsMatched] = useState(false)
+    const isSupported = typeof window !== "undefined" && typeof mediaQuery === "string"
 
     useEffect(() => {
+        if (!isSupported) return
         const mediaQueryList = window.matchMedia(mediaQuery)
 
         const updateMatch = (event: MediaQueryListEvent) => {
@@ -38,7 +40,7 @@ export const useMediaQuery = (mediaQuery: MediaQuery): boolean => {
         mediaQueryList.addEventListener("change", updateMatch)
 
         return () => mediaQueryList.removeEventListener("change", updateMatch)
-    }, [isMatched])
+    }, [mediaQuery])
 
     return isMatched
 }

--- a/src/use-media-query.ts
+++ b/src/use-media-query.ts
@@ -32,14 +32,14 @@ export const useMediaQuery = (mediaQuery: MediaQuery): boolean => {
         if (!isSupported) return
         const mediaQueryList = window.matchMedia(mediaQuery)
 
-        const updateMatch = (event: MediaQueryListEvent) => {
+        const handleMediaQuery = (event: MediaQueryListEvent) => {
             setIsMatched(event.matches)
         }
 
         setIsMatched(mediaQueryList.matches)
-        mediaQueryList.addEventListener("change", updateMatch)
+        mediaQueryList.addEventListener("change", handleMediaQuery)
 
-        return () => mediaQueryList.removeEventListener("change", updateMatch)
+        return () => mediaQueryList.removeEventListener("change", handleMediaQuery)
     }, [mediaQuery])
 
     return isMatched

--- a/src/use-on-click-outside.ts
+++ b/src/use-on-click-outside.ts
@@ -1,5 +1,5 @@
 import type { RefObject } from "react"
-import { useDocumentEventListener } from "./use-document-event-listener"
+import { useDocumentEventListener } from "@/use-document-event-listener"
 
 export const useOnClickOutside = <T extends HTMLElement>(target: RefObject<T>, handler: (event: MouseEvent) => void) => {
     const handleClickOutside = (event: MouseEvent) => {

--- a/src/use-online-status.ts
+++ b/src/use-online-status.ts
@@ -1,23 +1,23 @@
 "use client"
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
+import { useWindowEventListener } from "@/use-window-event-listener"
 
 export const useOnlineStatus = () => {
-    const [isOnline, setIsOnline] = useState(true)
+    const isSupported = typeof window !== "undefined" && typeof window.navigator !== "undefined"
+    const [isOnline, setIsOnline] = useState(false)
+
+    const updateOnlineStatus = useCallback(() => {
+        if (!isSupported) return
+        setIsOnline(navigator.onLine)
+    }, [isSupported])
 
     useEffect(() => {
-        const updateOnlineStatus = () => {
-            setIsOnline(navigator.onLine)
-        }
-
+        if (!isSupported) return
         updateOnlineStatus()
-        window.addEventListener("online", updateOnlineStatus)
-        window.addEventListener("offline", updateOnlineStatus)
+    }, [isSupported, updateOnlineStatus])
 
-        return () => {
-            window.removeEventListener("online", updateOnlineStatus)
-            window.removeEventListener("offline", updateOnlineStatus)
-        }
-    }, [])
+    useWindowEventListener("offline", updateOnlineStatus)
+    useWindowEventListener("online", updateOnlineStatus)
 
     return isOnline
 }

--- a/src/use-online-status.ts
+++ b/src/use-online-status.ts
@@ -6,18 +6,18 @@ export const useOnlineStatus = () => {
     const isSupported = typeof window !== "undefined" && typeof window.navigator !== "undefined"
     const [isOnline, setIsOnline] = useState(false)
 
-    const updateOnlineStatus = useCallback(() => {
+    const handleOnlineStatus = useCallback(() => {
         if (!isSupported) return
         setIsOnline(navigator.onLine)
     }, [isSupported])
 
     useEffect(() => {
         if (!isSupported) return
-        updateOnlineStatus()
-    }, [isSupported, updateOnlineStatus])
+        handleOnlineStatus()
+    }, [isSupported, handleOnlineStatus])
 
-    useWindowEventListener("offline", updateOnlineStatus)
-    useWindowEventListener("online", updateOnlineStatus)
+    useWindowEventListener("offline", handleOnlineStatus)
+    useWindowEventListener("online", handleOnlineStatus)
 
     return isOnline
 }

--- a/src/use-session-storage.ts
+++ b/src/use-session-storage.ts
@@ -93,12 +93,7 @@ export const useSessionStorage = <T>(key: string, initialValue?: T, options: Use
         sessionStorage.removeItem(key)
     }, [key, isSupported])
 
-    useEffect(() => {
-        getStorage()
-    }, [key, serializer])
-
-    useWindowEventListener(
-        "storage",
+    const handlestorage = useCallback(
         (event: StorageEvent) => {
             const { key, newValue } = event
             if (event.key === key) {
@@ -106,8 +101,17 @@ export const useSessionStorage = <T>(key: string, initialValue?: T, options: Use
                 setStorage(newContextValue)
             }
         },
-        { deps: [serializer, key, withEvent, isSupported], enabled: withEvent && isSupported },
+        [key, deserialize],
     )
+
+    useEffect(() => {
+        getStorage()
+    }, [key, serializer])
+
+    useWindowEventListener("storage", handlestorage, {
+        deps: [serializer, key, withEvent, isSupported],
+        enabled: withEvent && isSupported,
+    })
 
     return [storage, setValue, removeItem]
 }

--- a/src/use-window-event-listener.ts
+++ b/src/use-window-event-listener.ts
@@ -59,10 +59,10 @@ import { useEventListener, type EventListenerOptions } from "@/use-event-listene
  */
 export const useWindowEventListener = <K extends keyof WindowEventMap>(
     type: K,
-    event: (this: Window, ev: WindowEventMap[K]) => any,
+    handler: (this: Window, ev: WindowEventMap[K]) => any,
     options?: EventListenerOptions,
 ) => {
     const isSupported = typeof window !== "undefined" && typeof window.addEventListener === "function"
     if (!isSupported) return () => {}
-    return useEventListener(window, type, event, options)
+    return useEventListener(window, type, handler, options)
 }


### PR DESCRIPTION
## Description

This pull request refactors the `useEventListener` hook to support `deps` and `enabled` options. These enhancements give users more control over when the event listener should be attached or re-attached, improving both performance and flexibility. The `enabled` flag allows conditional activation, while `deps` ensures the event listener updates properly when dependencies change.

In addition, all hooks that internally use event listeners have been updated to use the new `useEventListener` implementation. This ensures consistency and improves maintainability across the codebase.

### Key Changes

- Enhanced `useEventListener` with `enabled` and `deps` options
- Replaced internal event logic in supported hooks with `useEventListener`
- Updated `isBrowser` function to `isSupported` to simplify runtime checks
- Renamed callback functions with `handle` prefix for naming clarity
- Renamed event callback variables to `handler` for consistency

## Checklist

- [x] Added documentation
- [x] The changes do not generate any warnings
- [x] I have performed a self-review of my own code
- [x] All tests have been added and pass successfully

## Notes
